### PR TITLE
Add fuzzing harness, in order to find panics through invalid input

### DIFF
--- a/kalk/fuzz/.gitignore
+++ b/kalk/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/kalk/fuzz/Cargo.toml
+++ b/kalk/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+
+[package]
+name = "kalk-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.kalk]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false

--- a/kalk/fuzz/fuzz_targets/parse.rs
+++ b/kalk/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &str| {
+    let mut ctx = kalk::parser::Context::new().set_timeout(Some(5));
+
+    // We don't care if it parses or not, we only care about if it panicked
+    // while parsing
+    let _ = kalk::parser::parse(&mut ctx, data);
+});


### PR DESCRIPTION
This adds support for fuzzing the library input using https://github.com/rust-fuzz/cargo-fuzz, as a way to find bugs by looking for invalid input that causes the library to panic.

This library isn't really security sensitive, but even so, fuzzing it can find parser errors and other areas where it can panic when you wouldn't expect it to.