### PR TITLE
update gmp-mpfr-sys to fix non gcc builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,8 @@ dependencies = [
 
 [[package]]
 name = "gmp-mpfr-sys"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57fdb339d49833021b1fded600ed240ae907e33909d5511a61dff884df7f16e"
+version = "1.4.7"
+source = "git+https://gitlab.com/tspiteri/gmp-mpfr-sys.git#21966f4bfb56c87d407eb14c72e92ef4e55856aa"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[patch.crates-io]
+gmp-mpfr-sys = { git = "https://gitlab.com/tspiteri/gmp-mpfr-sys.git" }
+
 [workspace]
 members = ["kalk", "cli"]
 

--- a/flake.nix
+++ b/flake.nix
@@ -21,15 +21,19 @@
 
           src = self;
 
-          nativeBuildInputs = with final; [ gcc ];
-
           outputs = [ "out" "lib" ];
 
           postInstall = ''
             moveToOutput "lib" "$lib"
           '';
 
-          cargoLock = { lockFile = self + "/Cargo.lock"; };
+          cargoLock = {
+            lockFile = self + "/Cargo.lock";
+            outputHashes = {
+              "gmp-mpfr-sys-1.4.7" =
+                "sha256-zHpGbEgh3MgAUVdlWrXq4Clj1boybi6DMOcsjgZbAh0=";
+            };
+          };
 
           buildInputs = with final; [ gmp mpfr libmpc ];
 


### PR DESCRIPTION
@PaddiM8 would be great if this could become a release, to make the fix in nixpkgs much easier.