### PR TITLE
Improve nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,5 +55,10 @@
       });
 
       defaultApp = forAllSystems (system: self.apps.${system}.kalker);
+
+      devShell = forAllSystems (system:
+        nixpkgs.legacyPackages.${system}.mkShell {
+          inputsFrom = builtins.attrValues (packages);
+        });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
         kalker = final.rustPlatform.buildRustPackage {
           pname = "kalker";
           version = "unstable";
+          description = "A CLI calculator";
 
           src = self;
 


### PR DESCRIPTION
Bring two small improvements to the nix flake

- Add deriavtion description
  Provides a description on nixos-search
- Add nix development shell
  Can be used to spin up a shell with all dependencies available provided by nix

