### PR TITLE
Fix Nix DevShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
           inherit system;
           overlays = [ self.overlay ];
         });
-    in {
+    in rec {
       overlay = final: prev: {
         kalker = final.rustPlatform.buildRustPackage {
           pname = "kalker";
@@ -58,7 +58,7 @@
 
       devShell = forAllSystems (system:
         nixpkgs.legacyPackages.${system}.mkShell {
-          inputsFrom = builtins.attrValues (packages);
+          inputsFrom = builtins.attrValues (packages.${system});
         });
     };
 }


### PR DESCRIPTION
The dev she'll.fajls to evaluate as it can't read record local variables. 
I marked the record as recursive so Nix can find the referenced packages (and nixos-search input stops failing)