### PR TITLE
Fix undefined function: '∏'

### DIFF
--- a/kalk/src/lexer.rs
+++ b/kalk/src/lexer.rs
@@ -236,6 +236,7 @@ impl<'a> Lexer<'a> {
 
         let value = match value.as_ref() {
             "Σ" | "∑" => String::from("sum"),
+            "∏" => String::from("prod"),
             "∫" => String::from("integrate"),
             "°" => String::from("deg"),
             _ => value,


### PR DESCRIPTION
Without this fix `prod(1,10,n)` works fine, but `∏(1,10,n)`
returns `Undefined function: '∏'.`