### PR TITLE
Make KalkError public

### DIFF
--- a/kalk/src/lib.rs
+++ b/kalk/src/lib.rs
@@ -4,7 +4,7 @@
 mod analysis;
 pub mod ast;
 pub mod calculation_result;
-mod errors;
+pub mod errors;
 mod integration_testing;
 mod interpreter;
 mod inverter;


### PR DESCRIPTION
I'm working on a library that will use kalk but I cannot easily handle `KalkError`s because I cannot import the type. This PR makes `KalkError` public to it can be consumed by external code.


Thanks!
