### PR TITLE
Fix: Reachable assertion (radix is to high)

### DIFF
--- a/kalk/src/parser.rs
+++ b/kalk/src/parser.rs
@@ -793,6 +793,10 @@ fn string_to_num(value: &str) -> Result<KalkFloat, KalkError> {
     }
 
     let base = get_base(value)?;
+    
+    if base > 36 {
+        return Err(KalkError::InvalidNumberLiteral(value.into()));
+    }
     if let Some(result) = crate::radix::parse_float_radix(&value.replace(' ', ""), base) {
         Ok(crate::float!(result))
     } else {


### PR DESCRIPTION
**platform**: Linux

**version**: Latest

**Overview**:

Reachable assertion code in core::char::to_digit:L349 caused by input “777_77” in REPL.

**Error Message**
"thread 'main' panicked at 'to_digit: radix is too high (maximum 36)", /home/nyw0102/s2fuzz/scripts/rust/library/core/src/char/methods.rs:349:13`

**ASAN log (SEGV)**

`AddressSanitizer:DEADLYSIGNAL
=================================================================
==1969104==ERROR: AddressSanitizer: SEGV on unknown address 0x100080006c6e (pc 0x55555573da2f bp 0x7ffffffea830 sp 0x7ffffffe9fe0 T0)
==1969104==The signal is caused by a READ memory access.
    #0 0x55555573da2f  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x1e9a2f) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #1 0x555557ed135a  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x297d35a) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #2 0x155555348d3f  (/lib/x86_64-linux-gnu/libc.so.6+0x174d3f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #3 0x555557ee61a0  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x29921a0) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #4 0x555557eca3d3  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x29763d3) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #5 0x555557ed1310  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x297d310) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #6 0x1555554fb5b3  (/lib/x86_64-linux-gnu/libgcc_s.so.1+0x175b3) (BuildId: e3a44e0da9c6e835d293ed8fd2882b4c4a87130c)
    #7 0x555557ee53de  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x29913de) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #8 0x555557f0161b  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x29ad61b) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #9 0x555557ed0d74  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x297cd74) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #10 0x555557ed6f43  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2982f43) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #11 0x555557ed6b83  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2982b83) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #12 0x555557ed7522  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2983522) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #13 0x555557ee5878  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2991878) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #14 0x555557ee5513  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2991513) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #15 0x555557ed7211  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2983211) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #16 0x5555556e7502  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x193502) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #17 0x555557551bf9  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x1ffdbf9) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #18 0x555557c4d502  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x26f9502) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #19 0x555557ae6513  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2592513) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #20 0x555557ad0dbc  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x257cdbc) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #21 0x555557acdcc0  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2579cc0) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #22 0x555557aca33a  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x257633a) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #23 0x555557ac71d2  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x25731d2) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #24 0x555557ac4226  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2570226) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #25 0x555557ac1e71  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x256de71) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #26 0x555557abb0a1  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x25670a1) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #27 0x555557ab7b90  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2563b90) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #28 0x555557ab4f30  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2560f30) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #29 0x555557aa75c0  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x25535c0) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #30 0x555557aa3ce6  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x254fce6) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #31 0x555557aa0dc6  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x254cdc6) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #32 0x555557a9a8a5  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x25468a5) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #33 0x555557a8f55c  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x253b55c) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #34 0x555557a8d54f  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x253954f) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #35 0x555557a897a4  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x25357a4) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #36 0x5555558f630d  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3a230d) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #37 0x5555558ffbf0  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3abbf0) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #38 0x5555558fe23d  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3aa23d) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #39 0x555555913381  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3bf381) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #40 0x555555ad1252  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x57d252) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #41 0x55555590f46d  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3bb46d) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #42 0x5555557e29fa  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x28e9fa) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #43 0x5555557cb3da  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x2773da) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #44 0x5555557cf616  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x27b616) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #45 0x555557ecff94  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x297bf94) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #46 0x5555557cf238  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x27b238) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #47 0x555555918c2f  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x3c4c2f) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)
    #48 0x1555551fdd8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #49 0x1555551fde3f  (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 962015aa9d133c6cbcfb31ec300596d7f44d3348)
    #50 0x5555556f26b4  (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x19e6b4) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/home/nyw0102/Test-Sets/kalker/target/x86_64-unknown-linux-gnu/debug/kalker+0x1e9a2f) (BuildId: 0e98ee328013dbca462706015cb56f4bb56e0f94) 
==1969104==ABORTING`

**Description**

First, input “777_77” goes into function “string_to_num” via parameter named “value”
`fn string_to_num(value: &str) -> Result<f64, KalkError> {
    let base = get_base(value)?;
    if let Some(result) = crate::radix::parse_float_radix(&value.replace(" ", ""), base) {
        Ok(result)
    } else {
        Err(KalkError::InvalidNumberLiteral(value.into()))
    }
}`
In this function, the “base” value is initialized by function get_base with parameter “value” which is “777_77”
`fn get_base(value: &str) -> Result<u8, KalkError> {
    let underscore_pos = if let Some(i) = value.find('_') {
        i
    } else {
        return Ok(10);
    };

    let subscript = value.chars().skip(underscore_pos + 1usize);
    if let Some(base) = crate::text_utils::parse_subscript(subscript) {
        Ok(base)
    } else {
        Err(KalkError::UnrecognizedBase)
    }
}`

In “get_base(value: &str) function, it erases all letters before “_” in string “777_77” and produces an iterator with value “77”. And this  returns the value from function “kalker::text_utils::parse_subscript” which is initialized the iterator.
`pub fn parse_subscript(chars: impl Iterator<Item = char>) -> Option<u8> {
    if let Ok(result) = subscript_to_normal(chars).parse::<u8>() {
        Some(result)
    } else {
        None
    }
}`

This function returns a value from kalker::text_utils::subscript_to_normal function initiated with “chars”

`pub fn subscript_to_normal(chars: impl Iterator<Item = char>) -> String {
    let mut regular = String::new();
    for c in chars {
        regular.push(match c {
            '₀' => '0',
            '₁' => '1',
            '₂' => '2',
            '₃' => '3',
            '₄' => '4',
            '₅' => '5',
            '₆' => '6',
            '₇' => '7',
            '₈' => '8',
            '₉' => '9',
            '₊' => '+',
            '₋' => '-',
            '₌' => '=',
            '₍' => '(',
            '₎' => ')',
            'ₖ' => 'k',
            'ₗ' => 'l',
            'ₘ' => 'm',
            'ₙ' => 'n',
            'ᵀ' => 'T',
            _ => c,
        });
    }

    return regular.trim().to_string();
}
`

This function matches each letter in “chars” by iteration. So, this function finally return the value Ok(”77”)
After this process, the “string_to_num” function initialize the value “base” as “Ok(”77”)
Then, this “base’ flows into function “parse_float_radix” as parameter named “base”.

`pub fn parse_float_radix(value: &str, radix: u8) -> Option<f64> {
    if radix == 10 {
        return if let Ok(result) = value.parse::<f64>() {
            Some(result)
        } else {
            None
        };
    }

    let mut sum = 0f64;
    let length = value.find('_').unwrap_or(value.len());
    let mut i = (value.find('.').unwrap_or(length) as i32) - 1;
    for c in value.chars() {
        if c == '_' {
            break;
        }

        if c == '.' {
            continue;
        }

        let digit = c.to_digit(radix as u32)? as f64;
        sum += digit * (radix as f64).powi(i as i32);
        i -= 1;
    }

    Some(sum)
}`
This function calls to_digit() function with parameter “77”
`pub const fn to_digit(self, radix: u32) -> Option<u32> {
        // If not a digit, a number greater than radix will be created.
        let mut digit = (self as u32).wrapping_sub('0' as u32);
        if radix > 10 {
            assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
            if digit < 10 {
                return Some(digit);
            }
            // Force the 6th bit to be set to ensure ascii is lower case.
            digit = (self as u32 | 0b10_0000).wrapping_sub('a' as u32).saturating_add(10);
        }
        // FIXME: once then_some is const fn, use it here
        if digit < radix { Some(digit) } else { None }
    }`
And finally to_digit() function gets value “77” as ‘radix’ parameter get it encounters assert!(radix <= 36, "to_digit: radix is too high (maximum 36)")

**How to Reproduce**

1. Run ‘kalker’ with command “./kalker -p 3 -a deg”.
2. In the started repl, insert “777_77”